### PR TITLE
feat(activity-definition): enable useContext with custom ValueSet for relative participation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,14 @@
 CHANGELOG
+
+## 1.4.5-beta.008 (2025-09-10)
+
+### Changed
+- **KT2_ActivityDefinition**: Updated profile version from 0.9.0 to 0.10.0
+- **KT2_ActivityDefinition**: Updated profile date to 2025-09-10
+- **KT2_ActivityDefinition**: Enabled useContext element with required binding to KoppeltaalUsageContext ValueSet
+- **KT2_ActivityDefinition**: Constrained useContext.value[x] to CodeableConcept only
+
+### Added
+- **KoppeltaalUsageContext**: New CodeSystem for usage context values (http://vzvz.nl/fhir/CodeSystem/koppeltaal-usage-context)
+- **KoppeltaalUsageContext_VS**: New ValueSet for usage context values (http://vzvz.nl/fhir/ValueSet/koppeltaal-usage-context)
+- **Code 026-RolvdNaaste**: "Rol van de naaste" - enables relatives to participate in patient care trajectory

--- a/input/fsh/codesystems/KoppeltaalUsageContext.fsh
+++ b/input/fsh/codesystems/KoppeltaalUsageContext.fsh
@@ -1,0 +1,17 @@
+CodeSystem: KoppeltaalUsageContext
+Id: koppeltaal-usage-context
+Title: "Koppeltaal Usage Context"
+Description: "Usage context values for Koppeltaal ActivityDefinitions"
+* ^status = #active
+* ^content = #complete
+* ^meta.lastUpdated = "2025-09-10T12:00:00+02:00"
+* ^url = "http://vzvz.nl/fhir/CodeSystem/koppeltaal-usage-context"
+* ^identifier.use = #official
+* ^identifier.value = "http://vzvz.nl/fhir/CodeSystem/koppeltaal-usage-context"
+* ^version = "1.0.0"
+* ^experimental = false
+* ^date = "2025-09-10T12:00:00+02:00"
+* insert ContactAndPublisher
+* ^caseSensitive = true
+* ^count = 1
+* #026-RolvdNaaste "Rol van de naaste" "Met de \"Rol van de naaste\" uitbreiding kunnen naasten van de patiënt/cliënt deelnemen aan het zorgtraject van de patiënt/cliënt."

--- a/input/fsh/profiles/KT2_ActivityDefinition.fsh
+++ b/input/fsh/profiles/KT2_ActivityDefinition.fsh
@@ -2,9 +2,9 @@ Profile: KT2_ActivityDefinition
 Parent: ActivityDefinition
 Id: KT2ActivityDefinition
 Description: "The (FHIR) ActivityDefinition (resource) describes an eHealth activity that is available for assignment to a patient. When assigning an eHealth activity to a patient, an eHealth Task is created, in which sub-activities are included as contained resources that refer to the main task via Task.partOf."
-* ^version = "0.9.0"
+* ^version = "0.10.0"
 * ^status = #draft
-* ^date = "2023-01-24"
+* ^date = "2025-09-10"
 * insert ContactAndPublisher
 * . ^short = "Description of an eHealth activity"
 * . ^comment = "The (FHIR) ActivityDefinition describes an eHealth activity available to assign to a patient. The assignment of an eHealth activity to a patient creates an eHealth Task (Task resource). This task can contain sub activities as contained resources which refer to the main task using the Task.partOf element."
@@ -22,9 +22,14 @@ Description: "The (FHIR) ActivityDefinition (resource) describes an eHealth acti
 * date ..0
 * publisher ..0
 * contact ..0
-* useContext ..0
+* useContext
   * ^definition = "The context for the content of the eHealth activity"
-  * ^comment = "E.g. the activity is targeted to a certain age group"
+  * ^comment = "E.g. the activity is targeted to a certain age group, or allows participation of patient relatives"
+  * value[x] only CodeableConcept
+  * value[x] from KoppeltaalUsageContext_VS (required)
+    * ^short = "Koppeltaal usage context values"
+    * ^definition = "Values from Koppeltaal Usage Context CodeSystem for defining usage context"
+    * ^binding.description = "Koppeltaal specific usage context values, including role of relatives"
 * jurisdiction ..0
 * jurisdiction ^definition = "This element is not used"
 * purpose ..0

--- a/input/fsh/valuesets/KoppeltaalUsageContext.fsh
+++ b/input/fsh/valuesets/KoppeltaalUsageContext.fsh
@@ -1,0 +1,16 @@
+ValueSet: KoppeltaalUsageContext_VS
+Id: koppeltaal-usage-context
+Title: "Koppeltaal Usage Context"
+Description: "Usage context values for Koppeltaal ActivityDefinitions"
+* ^meta.lastUpdated = "2025-09-10T12:00:00+02:00"
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+* ^url = "http://vzvz.nl/fhir/ValueSet/koppeltaal-usage-context"
+* ^identifier.use = #official
+* ^identifier.value = "http://vzvz.nl/fhir/ValueSet/koppeltaal-usage-context"
+* ^version = "1.0.0"
+* ^status = #active
+* ^experimental = false
+* ^date = "2025-09-10T12:00:00+02:00"
+* insert ContactAndPublisher
+* ^immutable = true
+* include codes from system KoppeltaalUsageContext

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,7 +7,7 @@ fhirVersion: 4.0.1
 FSHOnly: false
 applyExtensionMetadataToRoot: false
 status: draft
-version: 1.4.5-beta.007
+version: 1.4.5-beta.008
 copyrightYear: 2024+
 releaseLabel: ci-build
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html


### PR DESCRIPTION
- Enable useContext element in KT2_ActivityDefinition profile
- Constrain useContext.value[x] to CodeableConcept only
- Add required binding to KoppeltaalUsageContext ValueSet
- Create KoppeltaalUsageContext CodeSystem with "026-RolvdNaaste" code
- Update profile version from 0.9.0 to 0.10.0
- Bump package version to 1.4.5-beta.008